### PR TITLE
V11.0 changes

### DIFF
--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -101,6 +101,7 @@ private:
 	void processOpenMessage(message_ptr message) override;
 
 	friend class PeerConnection;
+	std::mutex mMutex;
 };
 
 template <typename Buffer> std::pair<const byte *, size_t> to_bytes(const Buffer &buf) {

--- a/src/icetransport.hpp
+++ b/src/icetransport.hpp
@@ -78,8 +78,8 @@ private:
 
 	Description::Role mRole;
 	string mMid;
-	std::chrono::milliseconds mTrickleTimeout;
-	std::atomic<GatheringState> mGatheringState;
+	std::chrono::milliseconds mTrickleTimeout = std::chrono::seconds(30);
+	std::atomic<GatheringState> mGatheringState = GatheringState::New;
 
 	candidate_callback mCandidateCallback;
 	gathering_state_callback mGatheringStateChangeCallback;


### PR DESCRIPTION
Fix 2 race conditions in datachannel.cpp: 
- race btwn NegociatedDataChannel::processOpenMessage() and ::open() when mLabel changes during open() and 'buffer' is overwriten
- race btwn send and close

Bonus: a couple of initializations as per Valgrind